### PR TITLE
Add margin to buttons and input to make some extra space so question …

### DIFF
--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -209,7 +209,7 @@ main {
   font-size: 36px;
   height: 60px;
   width: 690px;
-  margin: 25px 0px 0px 150px;
+  margin: 40px 0px 0px 150px;
 }
 
 .main-button__start-game,
@@ -227,7 +227,7 @@ main {
   font-size: 28px;
   height: 60px;
   width:200px;
-  margin: 25px;
+  margin: 40px 25px 25px 25px;
 }
 
 .main-button__submit-guess {


### PR DESCRIPTION
Added a 40px margin to buttons and input to create some space for longer names. Not perfect, but better than it was.
<img width="1440" alt="Screen Shot 2019-07-22 at 5 15 08 PM" src="https://user-images.githubusercontent.com/49172024/61672609-8017ba80-aca9-11e9-9099-c9d8e07be766.png">
